### PR TITLE
Add user option to only include favorites in Next Up

### DIFF
--- a/src/mypreferenceshome.html
+++ b/src/mypreferenceshome.html
@@ -132,6 +132,18 @@
                 </label>
 
             </div>
+
+            <div class="detailSection">
+                <h1>
+                    ${HeaderNextUp}
+                </h1>
+                <br />
+                <label class="checkboxContainer">
+                    <input class="chkNextUpFavoritesOnly" type="checkbox" is="emby-checkbox" />
+                    <span>${OptionNextUpFavoritesOnly}</span>
+                </label>
+            </div>
+
             <button is="emby-button" type="submit" class="raised button-submit block btnSave hide">
                 <span>${ButtonSave}</span>
             </button>

--- a/src/scripts/mypreferenceshome.js
+++ b/src/scripts/mypreferenceshome.js
@@ -115,6 +115,7 @@
     function loadForm(page, user, userSettings) {
 
         page.querySelector('.chkHidePlayedFromLatest').checked = user.Configuration.HidePlayedInLatest || false;
+        page.querySelector('.chkNextUpFavoritesOnly').checked = user.Configuration.NextUpFavoritesOnly || false;
 
         page.querySelector('#selectHomeSection1').value = userSettings.get('homesection0') || '';
         page.querySelector('#selectHomeSection2').value = userSettings.get('homesection1') || '';
@@ -161,6 +162,7 @@
     function saveUser(page, user, userSettingsInstance) {
 
         user.Configuration.HidePlayedInLatest = page.querySelector('.chkHidePlayedFromLatest').checked;
+        user.Configuration.NextUpFavoritesOnly = page.querySelector('.chkNextUpFavoritesOnly').checked;
 
         user.Configuration.LatestItemsExcludes = getCheckboxItems(".chkIncludeInLatest", page, false).map(function (i) {
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1973,5 +1973,7 @@
   "LabelAutomaticallyRefreshInternetMetadataEvery": "Automatically refresh metadata from the internet:",
   "Never": "Never",
   "EveryNDays": "Every {0} days",
-  "HeaderNewDevices": "New Devices"
+  "HeaderNewDevices": "New Devices",
+  "ButtonAddTag": "Add Tag",
+  "OptionNextUpFavoritesOnly": "Limit Next Up To Favorites Only"
 }

--- a/src/userparentalcontrol.html
+++ b/src/userparentalcontrol.html
@@ -24,7 +24,7 @@
                 <div>
                     <div class="detailSectionHeader">
                         <h1>${LabelBlockContentWithTags}</h1>
-                        <button is="emby-button" type="button" class="raised btnAddBlockedTag submit mini" style="margin-left:1em;" title="${ButtonAddUser}">
+                        <button is="emby-button" type="button" class="raised btnAddBlockedTag submit mini" style="margin-left:1em;" title="${ButtonAddTag}">
                             <i class="md-icon">add</i>
                             <span>${ButtonAdd}</span>
                         </button>


### PR DESCRIPTION
Dashboard PR to add option implemented in MediaBrowser/Emby/pull/2541.

Also fixes a minor incorrect tooltip (should be a separate commit; I can do that if it's an issue).